### PR TITLE
Add new scoreboard entries over entries with same time. (Fixes #12)

### DIFF
--- a/lib/game.dart
+++ b/lib/game.dart
@@ -813,16 +813,13 @@ class _SudokuGameState extends State<SudokuGame> with TickerProviderStateMixin {
 
           // also add it to our local list
           DateTime now = DateTime.now();
-          Score currentScore = Score(_stopwatch.elapsed + _stopwatchOffset, "${now.day} ${DateFormat.yMMM().format(now)}");
+          scores.add(Score(_stopwatch.elapsed + _stopwatchOffset, "${now.day} ${DateFormat.yMMM().format(now)}"));
+          scores.sort((a, b) {
+            int ret = a.time.compareTo(b.time);
 
-          int index = 0;
-          while (index < scores.length) {
-            if (scores[index].time >= currentScore.time) {
-              break;
-            }
-            index++;
-          }
-          scores.insert(index, currentScore);
+            // if times are equal, place our new time above
+            return ret == 0 ? -1 : ret;
+          });
 
           if (scores.length > 10) {
             scores.removeRange(10, scores.length);

--- a/lib/game.dart
+++ b/lib/game.dart
@@ -813,8 +813,16 @@ class _SudokuGameState extends State<SudokuGame> with TickerProviderStateMixin {
 
           // also add it to our local list
           DateTime now = DateTime.now();
-          scores.add(Score(_stopwatch.elapsed + _stopwatchOffset, "${now.day} ${DateFormat.yMMM().format(now)}"));
-          scores.sort((a, b) => a.time.compareTo(b.time));
+          Score currentScore = Score(_stopwatch.elapsed + _stopwatchOffset, "${now.day} ${DateFormat.yMMM().format(now)}");
+
+          int index = 0;
+          while (index < scores.length) {
+            if (scores[index].time >= currentScore.time) {
+              break;
+            }
+            index++;
+          }
+          scores.insert(index, currentScore);
 
           if (scores.length > 10) {
             scores.removeRange(10, scores.length);

--- a/lib/game.dart
+++ b/lib/game.dart
@@ -817,7 +817,7 @@ class _SudokuGameState extends State<SudokuGame> with TickerProviderStateMixin {
           scores.sort((a, b) => a.time.compareTo(b.time));
 
           if (scores.length > 10) {
-            scores.removeRange(9, scores.length - 1);
+            scores.removeRange(10, scores.length);
           }
 
           _stopwatch.stop();

--- a/lib/save_manager.dart
+++ b/lib/save_manager.dart
@@ -54,11 +54,19 @@ class SaveManager {
     scores.removeWhere((string) => !string.contains('#'));
 
     DateTime now = DateTime.now();
-    scores.add("${now.day} ${DateFormat.yMMM().format(now)}#${time.inSeconds}");
+    String currentScore = "${now.day} ${DateFormat.yMMM().format(now)}#${time.inSeconds}");
 
-    scores.sort((String a, String b) =>
-        int.parse(a.substring(a.indexOf('#') + 1, a.length)).compareTo(int.parse(b.substring(b.indexOf('#') + 1, b.length)))
-    );
+    int index = 0;
+    int currentScoreTime = currentScore.substring(currentScore.indexOf('#') + 1);
+    while (index < scores.length) {
+      String otherScore = scores[index];
+      int otherScoreTime = otherScore.substring(otherScore.indexOf('#') + 1);
+      if (otherScoreTime >= currentScoreTime) {
+        break;
+      }
+      index++;
+    }
+    scores.insert(index, currentScore);
 
     if(scores.length > 10) {
       scores.removeRange(10, scores.length);

--- a/lib/save_manager.dart
+++ b/lib/save_manager.dart
@@ -54,19 +54,15 @@ class SaveManager {
     scores.removeWhere((string) => !string.contains('#'));
 
     DateTime now = DateTime.now();
-    String currentScore = "${now.day} ${DateFormat.yMMM().format(now)}#${time.inSeconds}");
+    scores.add("${now.day} ${DateFormat.yMMM().format(now)}#${time.inSeconds}");
 
-    int index = 0;
-    int currentScoreTime = currentScore.substring(currentScore.indexOf('#') + 1);
-    while (index < scores.length) {
-      String otherScore = scores[index];
-      int otherScoreTime = otherScore.substring(otherScore.indexOf('#') + 1);
-      if (otherScoreTime >= currentScoreTime) {
-        break;
-      }
-      index++;
-    }
-    scores.insert(index, currentScore);
+    scores.sort((String a, String b) {
+      int ret = int.parse(a.substring(a.indexOf('#') + 1, a.length)).compareTo(
+          int.parse(b.substring(b.indexOf('#') + 1, b.length)));
+
+      // if times are equal, place our new time above
+      return ret == 0 ? -1 : ret;
+    });
 
     if(scores.length > 10) {
       scores.removeRange(10, scores.length);


### PR DESCRIPTION
Also applying the fix from #11 to the generated scoreboard after a game is won.
(Turns out there are 2 places where the leaderboard is being edited: once when saving, and once before displaying after a winning game.)

If there is a need i can post these as 2 separate pull requests.